### PR TITLE
remove wkhtmltopdf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM openeuler/openeuler:22.03
 
-ARG wkhtmltox_url
-ARG wkhtmltox_rpm
 ARG user=meetingserver
 ARG group=meetingserver
 ARG uid=1000
@@ -18,7 +16,6 @@ COPY --chown=meetingserver ./requirements.txt /home/meetingserver/app-meeting-se
 # 2.install
 RUN yum install -y shadow wget git openssl openssl-devel tzdata python3-devel mariadb-devel python3-pip libXext libjpeg xorg-x11-fonts-75dpi xorg-x11-fonts-Type1 gcc
 RUN pip3 install -r /home/meetingserver/app-meeting-server/requirements.txt && rm -rf /home/meetingserver/app-meeting-server/requirements.txt
-RUN wget ${wkhtmltox_url} && rpm -i ${wkhtmltox_rpm} && rm -f ${wkhtmltox_rpm}
 
 # 3.clean
 RUN groupadd -g ${gid} ${group}


### PR DESCRIPTION
由于wkhtmltoimage不再存在使用场景，在Docker中移除对wkhtmltopdf的安装